### PR TITLE
누락된 pyobjc 의존성 추가 (ApplicationServices, AVFoundation)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ soundfile
 pyobjc-framework-Quartz
 pyobjc-framework-Cocoa
 pyobjc-framework-ServiceManagement
+pyobjc-framework-ApplicationServices
+pyobjc-framework-AVFoundation


### PR DESCRIPTION
## 문제

`python3 -m vvrite` 실행 시 다음 오류가 발생합니다:

    ModuleNotFoundError: No module named 'ApplicationServices'

해당 오류를 해결한 후에도 연쇄적으로:

    ModuleNotFoundError: No module named 'AVFoundation'

## 원인

코드에서 `ApplicationServices`와 `AVFoundation`을 import하고 있지만,
`requirements.txt`에 해당 pyobjc 패키지가 누락되어 있습니다.

- `ApplicationServices`: `main.py`, `settings.py`, `onboarding.py`에서 사용
- `AVFoundation`: `onboarding.py`에서 사용

## 수정 내용

`requirements.txt`에 다음 패키지를 추가합니다:
- `pyobjc-framework-ApplicationServices`
- `pyobjc-framework-AVFoundation`

---

P.S. 앱을 만들어주셔서 감사합니다! 잘 쓰도록 하겠습니다 🙏