### PR TITLE
fix: update menu bar hotkey display when shortcut is changed

### DIFF
--- a/vvrite/settings.py
+++ b/vvrite/settings.py
@@ -36,7 +36,7 @@ from vvrite.audio_devices import (
 )
 from vvrite.locales import t, SUPPORTED_LANGUAGES
 from vvrite.preferences import Preferences
-from vvrite.widgets import ShortcutField
+from vvrite.widgets import ShortcutField, format_shortcut
 
 
 class SettingsWindowController(NSObject):
@@ -160,6 +160,7 @@ class SettingsWindowController(NSObject):
         self._shortcut_field = ShortcutField.alloc().initWithFrame_preferences_(
             NSMakeRect(20, y, 280, 24), self._prefs
         )
+        self._shortcut_field._on_change = self._update_hotkey_display
         content.addSubview_(self._shortcut_field)
 
         change_btn = NSButton.alloc().initWithFrame_(NSMakeRect(310, y, 80, 24))
@@ -491,6 +492,14 @@ class SettingsWindowController(NSObject):
     @objc.typedSelector(b"v@:@")
     def pollPermissions_(self, timer):
         self._update_permissions()
+
+    def _update_hotkey_display(self):
+        delegate = NSApp.delegate()
+        if delegate and delegate._status_bar:
+            hotkey_str = format_shortcut(
+                self._prefs.hotkey_keycode, self._prefs.hotkey_modifiers
+            )
+            delegate._status_bar.setHotkeyDisplay_(hotkey_str)
 
     @objc.typedSelector(b"v@:@")
     def changeShortcut_(self, sender):

--- a/vvrite/status_bar.py
+++ b/vvrite/status_bar.py
@@ -13,6 +13,7 @@ from AppKit import (
 )
 
 from vvrite.locales import t
+from vvrite.widgets import format_shortcut
 
 _READY_STATES = {"ready", "recording", "transcribing"}
 
@@ -57,8 +58,10 @@ class StatusBarController(NSObject):
         self._menu.addItem_(NSMenuItem.separatorItem())
 
         # Hotkey display
+        prefs = self._delegate._prefs
+        hotkey_str = format_shortcut(prefs.hotkey_keycode, prefs.hotkey_modifiers)
         self._hotkey_item = NSMenuItem.alloc().initWithTitle_action_keyEquivalent_(
-            t("menu.hotkey", hotkey="⌥Space"), None, ""
+            t("menu.hotkey", hotkey=hotkey_str), None, ""
         )
         self._hotkey_item.setEnabled_(False)
         self._menu.addItem_(self._hotkey_item)

--- a/vvrite/widgets.py
+++ b/vvrite/widgets.py
@@ -72,6 +72,7 @@ class ShortcutField(NSTextField):
         self._keycode_key = str(keycode_key)
         self._modifiers_key = str(modifiers_key)
         self._capturing = False
+        self._on_change = None
         self.setEditable_(False)
         self.setSelectable_(False)
         self.setBezeled_(True)
@@ -121,6 +122,8 @@ class ShortcutField(NSTextField):
         setattr(self._prefs, self._modifiers_key, int(cg_flags))
         self._capturing = False
         self._update_display()
+        if self._on_change:
+            self._on_change()
 
     def acceptsFirstResponder(self):
         return True


### PR DESCRIPTION
## Summary
- 메뉴바 핫키 표시가 `⌥Space`로 하드코딩되어 있어, 설정에서 단축키를 변경해도 메뉴바에 반영되지 않던 문제 수정
- `status_bar.py`: 초기화 시 Preferences에서 실제 단축키를 읽어서 표시
- `widgets.py`: ShortcutField에 `_on_change` 콜백 추가
- `settings.py`: 단축키 변경 시 메뉴바 즉시 갱신

Closes #4

## Test plan
- [x] `python -m unittest discover tests/` 전체 통과 (123 tests)
- [x] 설정에서 단축키 변경 후 메뉴바 표시가 즉시 갱신되는지 확인
- [x] 앱 재시작 후에도 변경된 단축키가 메뉴바에 올바르게 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)